### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/generate_dependabot.yml
+++ b/.github/workflows/generate_dependabot.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         
       - name: Generate dependabot.yml
-        uses: Makeshift/generate-dependabot-glob-action@master
+        uses: Makeshift/generate-dependabot-glob-action@v1.3.4
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v5.0.2


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[Makeshift/generate-dependabot-glob-action](https://github.com/Makeshift/generate-dependabot-glob-action)** published a new release **[v1.3.4](https://github.com/Makeshift/generate-dependabot-glob-action/releases/tag/v1.3.4)** on 2023-05-03T12:38:57Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v5.0.2](https://github.com/peter-evans/create-pull-request/releases/tag/v5.0.2)** on 2023-06-14T01:20:17Z
